### PR TITLE
fix: Routing base case

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -101,11 +101,11 @@ func (r *R) resourceParts(parts []string) *R {
 // Resource defines a new resource below current resource
 func (r *R) Resource(locator string) *R {
 
-	locator = strings.TrimPrefix(locator, "/")
 	if locator == "" {
 		return r
 	}
 
+	locator = strings.TrimPrefix(locator, "/")
 	parts := strings.Split(locator, "/")
 
 	return r.resourceParts(parts)

--- a/resource_test.go
+++ b/resource_test.go
@@ -36,7 +36,7 @@ func TestR_Resource_BaseCaseSlash(t *testing.T) {
 	root := NewResource()
 	r := root.Resource("/")
 
-	AssertEqual(t, r, root)
+	AssertEqual(t, r, root.children[0])
 }
 
 func TestR_Resource_NextCase(t *testing.T) {


### PR DESCRIPTION
Explanation:
If we have a route like this '/hello/world/' splitting by slashes:

```
["", "hello", "world", ""]
```

By default, leading slash is trimmed out, so actually we have:

```
["hello", "world", ""]
```

Now the trailing item (empty string) should be a child of the resource
itself (that allow you to handle resources ending in slash). That is
working now.

The second part is the base case. Since leading slash is being trimmed
out, these two cases should be equivalent:

```
r.Resource("") == r.Resource("/")
```

Now it is not! `r.Resource("")` is the `r` itself whereas `r.Resource("/")`
is a child node with the empty string path.


With this fix behavior is consistent in all cases.