### PR TITLE
fix: path part is now query unescaped

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -47,7 +47,7 @@ func (r *R) Match(path string, parameters map[string]string) (result *R) {
 
 	parts := strings.SplitN(path, "/", 2)
 
-	current, err := url.PathUnescape(parts[0])
+	current, err := url.QueryUnescape(parts[0])
 	if nil != err {
 		// TODO: maybe log debug "unescape" error ??
 		return

--- a/resource_test.go
+++ b/resource_test.go
@@ -50,6 +50,18 @@ func TestR_Resource_NextCase(t *testing.T) {
 	AssertEqual(t, b.Parent, a)
 }
 
+func TestR_Match_DecodeUriComponent(t *testing.T) {
+
+	r := NewResource()
+	r.Resource("/users/{userId}/history")
+
+	parameters := map[string]string{}
+
+	r.Match("/users/a+b%20c/history", parameters)
+
+	AssertEqual(t, parameters["userId"], "a b c")
+}
+
 func TestR_Match(t *testing.T) {
 
 	r := NewResource()


### PR DESCRIPTION
Actually the only change is char `+` is correctly unescaped to space